### PR TITLE
Feat pages view

### DIFF
--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, MouseEvent } from "react";
-import { useEffect, useState } from "react";
+import React, { ReactNode, MouseEvent, TouchEventHandler } from "react";
+import { useEffect, useState, useRef } from "react";
 import styled from "styled-components";
 
 type ViewTableProps = {
@@ -17,8 +17,6 @@ type ViewTableProps = {
         total: number;
     };
 };
-
-type TimeBlockProps = {};
 
 const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
     const [rows, setRows] = useState<ReactNode[]>([]);
@@ -38,6 +36,43 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
             : data?.attendee.length / total;
     };
 
+    const mouseDown = (e: MouseEvent<HTMLSpanElement>) => {
+        ref.current = true;
+    };
+
+    const mouseMove = (e: MouseEvent<HTMLSpanElement>) => {
+        if (!ref.current) return;
+        else {
+            const clickedTime = Number(e.currentTarget.dataset["id"]);
+            setClickedTime(clickedTime);
+        }
+    };
+
+    const mouseUp = (e: MouseEvent<HTMLSpanElement>) => {
+        ref.current = false;
+    };
+
+    const touchStart = (e: any) => {
+        ref.current = true;
+    };
+
+    const touchMove = (e: any) => {
+        if (!ref.current) return;
+        else {
+            const target = document.elementFromPoint(
+                e.targetTouches[0].clientX,
+                e.targetTouches[0].clientY
+            );
+            setClickedTime(Number(target?.getAttribute("data-id")));
+        }
+    };
+
+    const touchEnd = (e: any) => {
+        ref.current = false;
+    };
+
+    const ref = useRef<boolean>(false);
+
     useEffect(() => {
         // 가상의 fetch
         // setRows([]);
@@ -56,6 +91,12 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
                                 key={key}
                                 data-id={key}
                                 onClick={timeClick}
+                                onMouseDown={mouseDown}
+                                onMouseUp={mouseUp}
+                                onMouseMove={mouseMove}
+                                onTouchStart={touchStart}
+                                onTouchEnd={touchEnd}
+                                onTouchMove={touchMove}
                                 colorWeight={colorWeight}
                             ></TimeBlock>
                         );
@@ -81,7 +122,7 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
             <Time>{time}</Time>
             <Table>
                 <TableHead>{head}</TableHead>
-                <TableBody>{rows}</TableBody>
+                <TableBody onMouseLeave={mouseUp}>{rows}</TableBody>
             </Table>
         </Container>
     );

--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -132,6 +132,7 @@ export default ViewTable;
 
 const Container = styled.div`
     width: 97%;
+    height: 845px;
     margin: 0 auto;
     font-weight: 300;
     font-family: "Pretendard";

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import { useEffect, useState } from "react";
+import { useEffect, useState, RefObject } from "react";
 import ViewTable from "../../../components/event/View/ViewTable";
 import Navbar from "../../../components/common/Navbar";
 import shareNav from "../../../public/assets/shareNav.svg";
@@ -68,6 +68,7 @@ const Test: NextPage = () => {
     const [clickedData, setClickedData] = useState<
         TimeDataType["times"][0] | undefined
     >();
+
     // const [mostJoinTimes, setMostJoinTimes] = useState<TimeDataType["times"]>(
     //     []
     // );

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -61,6 +61,60 @@ const Test: NextPage = () => {
                 attendee: ["경륜", "상오", "영로"],
                 absentee: ["세호", "재석"],
             },
+
+            {
+                time: 121,
+                attendee: ["경륜", "상오", "지은"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 122,
+                attendee: ["경륜", "상오", "지은"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 123,
+                attendee: ["경륜", "상오", "지은"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 124,
+                attendee: ["경륜", "상오", "영로"],
+                absentee: ["세호", "재석"],
+            },
+
+            {
+                time: 125,
+                attendee: ["경륜", "상오", "재훈"],
+                absentee: ["세호", "재석"],
+            },
+
+            {
+                time: 126,
+                attendee: ["경륜", "상오", "윤하"],
+                absentee: ["세호", "재석"],
+            },
+
+            {
+                time: 127,
+                attendee: ["경륜", "상오", "재상"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 136,
+                attendee: ["경륜", "상오", "영로"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 137,
+                attendee: ["경륜", "상오", "영로"],
+                absentee: ["세호", "재석"],
+            },
+            {
+                time: 138,
+                attendee: ["경륜", "상오", "영로"],
+                absentee: ["세호", "재석"],
+            },
         ],
         total: 5,
     });
@@ -69,6 +123,13 @@ const Test: NextPage = () => {
         TimeDataType["times"][0] | undefined
     >();
 
+    const getPosition = (clickedData: TimeDataType["times"][0]) => {
+        if (clickedData.time % 100 <= 24) {
+            return "bottom";
+        } else {
+            return "top";
+        }
+    };
     // const [mostJoinTimes, setMostJoinTimes] = useState<TimeDataType["times"]>(
     //     []
     // );
@@ -108,7 +169,7 @@ const Test: NextPage = () => {
                 setClickedTime={setClickedTime}
             />
             {clickedData && (
-                <Container>
+                <Container position={getPosition(clickedData)}>
                     <Attendee clickedData={clickedData} />
                     {/* <ThinLine />
                     <MaximumTime times={mostJoinTimes} /> */}
@@ -120,6 +181,13 @@ const Test: NextPage = () => {
 
 export default Test;
 
-const Container = styled.div`
-    width: 100%;
+const Container = styled.div<{ position: string }>`
+    width: 376px;
+    background-color: white;
+    display: inline-block;
+    position: fixed;
+    margin: 0 auto;
+    top: ${(props) => (props.position === "bottom" ? "60%" : "50%")};
+    border: 1px solid gray;
+    border-radius: 5px;
 `;

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -64,12 +64,12 @@ const Test: NextPage = () => {
 
             {
                 time: 121,
-                attendee: ["경륜", "상오", "지은"],
+                attendee: ["경륜", "상오", "지금"],
                 absentee: ["세호", "재석"],
             },
             {
                 time: 122,
-                attendee: ["경륜", "상오", "지은"],
+                attendee: ["경륜", "상오", "지동"],
                 absentee: ["세호", "재석"],
             },
             {
@@ -123,13 +123,6 @@ const Test: NextPage = () => {
         TimeDataType["times"][0] | undefined
     >();
 
-    const getPosition = (clickedData: TimeDataType["times"][0]) => {
-        if (clickedData.time % 100 <= 24) {
-            return "bottom";
-        } else {
-            return "top";
-        }
-    };
     // const [mostJoinTimes, setMostJoinTimes] = useState<TimeDataType["times"]>(
     //     []
     // );
@@ -169,7 +162,7 @@ const Test: NextPage = () => {
                 setClickedTime={setClickedTime}
             />
             {clickedData && (
-                <Container position={getPosition(clickedData)}>
+                <Container>
                     <Attendee clickedData={clickedData} />
                     {/* <ThinLine />
                     <MaximumTime times={mostJoinTimes} /> */}
@@ -181,13 +174,13 @@ const Test: NextPage = () => {
 
 export default Test;
 
-const Container = styled.div<{ position: string }>`
-    width: 376px;
+const Container = styled.div`
+    width: 372px;
     background-color: white;
     display: inline-block;
     position: fixed;
     margin: 0 auto;
-    top: ${(props) => (props.position === "bottom" ? "60%" : "50%")};
+    top: 85%;
     border: 1px solid gray;
     border-radius: 5px;
 `;


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 :  테이블 뷰 드래그 시 표시되는 세부 투표자 정보 시인성이 안좋다
> 작성일: 2022.12.26

# 종류
- [ ] 성능 개선
- [ ] 코드 개선
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 기타

# 변경내용

테이블 뷰 드래그 시 표시되는 세부 투표자 정보를 하단에 고정시켜 UX 개선

# 테스트
[간단 설명]