### PR TITLE
Feat api jh

### DIFF
--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, MouseEvent } from "react";
 import { useEffect, useState, useRef } from "react";
 import styled from "styled-components";
+import css from "styled-jsx/css";
 
 type ViewTableProps = {
     info: {
@@ -16,9 +17,25 @@ type ViewTableProps = {
         }[];
         total: number;
     };
+    selectedWeeks: any;
 };
 
-const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
+const week = {
+    SUNDAY: 1,
+    MONDAY: 2,
+    TUESDAY: 3,
+    WEDNESDAY: 4,
+    THURSDAY: 5,
+    FRIDAY: 6,
+    SATURDAY: 7,
+};
+
+const ViewTable = ({
+    info,
+    setClickedTime,
+    timeData,
+    selectedWeeks,
+}: ViewTableProps) => {
     const [rows, setRows] = useState<ReactNode[]>([]);
     const [head, setHead] = useState<ReactNode[]>([]);
     const [time, setTime] = useState<ReactNode[]>([]);
@@ -74,6 +91,10 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
     const ref = useRef<boolean>(false);
 
     useEffect(() => {
+        for (let i = 0; i < selectedWeeks.length; i++) {
+            //@ts-ignore
+            selectedWeeks[i] = week[selectedWeeks[i]];
+        }
         // 가상의 fetch
         // setRows([]);
         const makeRows = (info: any, r: number) => {
@@ -85,6 +106,10 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
                             key,
                             timeData.total
                         );
+                        const disabled = selectedWeeks.includes(idx + 1)
+                            ? false
+                            : true;
+
                         return (
                             <TimeBlock
                                 col={info.col.length}
@@ -98,6 +123,7 @@ const ViewTable = ({ info, setClickedTime, timeData }: ViewTableProps) => {
                                 onTouchEnd={touchEnd}
                                 onTouchMove={touchMove}
                                 colorWeight={colorWeight}
+                                disabled={disabled}
                             ></TimeBlock>
                         );
                     })}
@@ -171,11 +197,17 @@ const TableBody = styled.div`
     }
 `;
 
-const TimeBlock = styled.span<{ col: number; colorWeight: number }>`
+const TimeBlock = styled.span<{
+    col: number;
+    colorWeight: number;
+    disabled: boolean;
+}>`
     display: block;
     width: ${(props) => (props.col ? `${100 / props.col}%` : "10%")};
     background-color: ${(props) =>
-        props.colorWeight
+        props.disabled
+            ? "#2B2B2B"
+            : props.colorWeight
             ? `rgba(50, 120, 222,${props.colorWeight})`
             : "#FFFFFF"};
     height: 13px;

--- a/meezzle-front/pages/event/[eid]/congratulations.tsx
+++ b/meezzle-front/pages/event/[eid]/congratulations.tsx
@@ -5,6 +5,8 @@ import styled from "styled-components";
 import character from "../../../public/assets/character.svg";
 import Image from "next/image";
 import OrangeBtn from "../../../components/common/OrangeBtn";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 interface Props {
     params: {
@@ -20,8 +22,16 @@ const Congratulations: NextPage<Props> = ({ params }) => {
         navigator.clipboard
             .writeText(window.location.href.replace("congratulations", "info"))
             .then(() => {
-                // 토스트 메세지 복사되었습니다 띄우기
-                console.log("Text copied to clipboard...");
+                toast("링크가 복사되었습니다.", {
+                    position: "top-center",
+                    autoClose: 2000,
+                    hideProgressBar: true,
+                    closeOnClick: true,
+                    pauseOnHover: false,
+                    draggable: true,
+                    progress: undefined,
+                    theme: "light",
+                });
             })
             .catch((err) => {
                 console.log("Something went wrong", err);
@@ -37,6 +47,17 @@ const Congratulations: NextPage<Props> = ({ params }) => {
             <Navbar>
                 <></>
             </Navbar>
+            <Container
+                position="top-center"
+                autoClose={2000}
+                hideProgressBar
+                newestOnTop={false}
+                closeOnClick
+                rtl={false}
+                draggable
+                pauseOnHover={false}
+                theme="light"
+            />
             <Section>
                 <Image src={character} />
                 <SectionText>이벤트가 생성되었어요!</SectionText>
@@ -64,6 +85,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         return { props: {} };
     }
 };
+
+export const Container = styled(ToastContainer)`
+    .Toastify__toast {
+        font-family: "Pretendard";
+        font-weight: 500;
+        margin-top: 20px;
+        text-align: center;
+    }
+`;
 
 const Body = styled.div`
     display: flex;

--- a/meezzle-front/pages/event/[eid]/congratulations.tsx
+++ b/meezzle-front/pages/event/[eid]/congratulations.tsx
@@ -18,24 +18,36 @@ const Congratulations: NextPage<Props> = ({ params }) => {
     const router = useRouter();
     const { eid } = params;
 
+    const isVoter = router.query.voter === "true";
+
     const onShare = () => {
-        navigator.clipboard
-            .writeText(window.location.href.replace("congratulations", "info"))
-            .then(() => {
-                toast("링크가 복사되었습니다.", {
-                    position: "top-center",
-                    autoClose: 2000,
-                    hideProgressBar: true,
-                    closeOnClick: true,
-                    pauseOnHover: false,
-                    draggable: true,
-                    progress: undefined,
-                    theme: "light",
+        let URL = "";
+        if (isVoter) {
+            URL = window.location.href.replace(
+                "congratulations?voter=true",
+                "view"
+            );
+            router.push(URL);
+        } else {
+            URL = window.location.href.replace("congratulations", "info");
+            navigator.clipboard
+                .writeText(URL)
+                .then(() => {
+                    toast("링크가 복사되었습니다.", {
+                        position: "top-center",
+                        autoClose: 2000,
+                        hideProgressBar: true,
+                        closeOnClick: true,
+                        pauseOnHover: false,
+                        draggable: true,
+                        progress: undefined,
+                        theme: "light",
+                    });
+                })
+                .catch((err) => {
+                    console.log("Something went wrong", err);
                 });
-            })
-            .catch((err) => {
-                console.log("Something went wrong", err);
-            });
+        }
     };
 
     const goHome = () => {
@@ -60,12 +72,20 @@ const Congratulations: NextPage<Props> = ({ params }) => {
             />
             <Section>
                 <Image src={character} />
-                <SectionText>이벤트가 생성되었어요!</SectionText>
+                <SectionText>
+                    {isVoter
+                        ? "투표가 완료되었어요!"
+                        : "이벤트가 생성되었어요!"}
+                </SectionText>
             </Section>
             <Footer>
-                <FooterText>다른 친구들에게 공유해봐요!</FooterText>
+                <FooterText>
+                    {isVoter
+                        ? "다른 사람들은 어디에 투표했을까?"
+                        : "다른 친구들에게 공유해봐요!"}
+                </FooterText>
                 <OrangeBtn style={{ filter: "none" }} onClick={onShare}>
-                    공유하기
+                    {isVoter ? "통계보기" : "공유하기"}
                 </OrangeBtn>
                 <HomeBtn onClick={goHome}>홈으로 돌아갈래요</HomeBtn>
             </Footer>

--- a/meezzle-front/pages/event/[eid]/info.tsx
+++ b/meezzle-front/pages/event/[eid]/info.tsx
@@ -1,7 +1,7 @@
 import type { GetServerSideProps, NextPage } from "next";
 import styled from "styled-components";
 import { useEffect } from "react";
-
+import { Container } from "./congratulations";
 import Navbar from "../../../components/common/Navbar";
 import VoteLogin from "../../../components/event/Vote/Login";
 import { useEvent } from "../../../hooks/api/events";
@@ -250,8 +250,16 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
         navigator.clipboard
             .writeText(window.location.href)
             .then(() => {
-                // 토스트 메세지 복사되었습니다 띄우기
-                console.log("Text copied to clipboard...");
+                toast("링크가 복사되었습니다.", {
+                    position: "top-center",
+                    autoClose: 2000,
+                    hideProgressBar: true,
+                    closeOnClick: true,
+                    pauseOnHover: false,
+                    draggable: true,
+                    progress: undefined,
+                    theme: "light",
+                });
             })
             .catch((err) => {
                 console.log("Something went wrong", err);
@@ -296,7 +304,18 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
                             useDisable={!isLoggedIn && true}
                             Click={Click2Vote}
                         ></Btn>
-                        <ToastContainer
+                        <Container
+                            position="top-center"
+                            autoClose={2000}
+                            hideProgressBar
+                            newestOnTop={false}
+                            closeOnClick
+                            rtl={false}
+                            draggable
+                            pauseOnHover={false}
+                            theme="light"
+                        />
+                        {/* <ToastContainer
                             position="bottom-center"
                             autoClose={2000}
                             hideProgressBar
@@ -307,7 +326,7 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
                             draggable
                             pauseOnHover={false}
                             theme="colored"
-                        />
+                        /> */}
                         <Link
                             href={{
                                 pathname: "/event/[eid]/view",

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -1,4 +1,3 @@
-import { NextPage } from "next";
 import { useEffect, useState } from "react";
 import ViewTable from "../../../components/event/View/ViewTable";
 import Navbar from "../../../components/common/Navbar";
@@ -8,6 +7,9 @@ import H1 from "../../../components/event/View/Title";
 import Tooltip from "../../../components/event/View/Tooltip";
 import Attendee from "../../../components/event/View/Attendee";
 import styled from "styled-components";
+import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { useParticipants } from "../../../hooks/api/participants";
 
 type tableInfoType = {
     row: number;
@@ -34,7 +36,19 @@ const Body = styled.div`
     align-items: center;
 `;
 
-const Test: NextPage = () => {
+interface Props {
+    params: {
+        eid: string;
+    };
+}
+
+const TableView: NextPage<Props> = ({ params }) => {
+    const router = useRouter();
+    const { eid } = params;
+    const { data, isLoading } = useParticipants(eid);
+    const selectableTimes = isLoading ? null : data.data;
+    console.log(selectableTimes);
+
     const [tableInfo, setTableInfo] = useState<tableInfoType>({
         row: 48,
         col: {
@@ -55,27 +69,6 @@ const Test: NextPage = () => {
                 absentee: ["세호", "재석"],
             },
             {
-                time: 106,
-                attendee: ["경륜", "상오", "영로"],
-                absentee: ["세호", "재석"],
-            },
-
-            {
-                time: 121,
-                attendee: ["경륜", "상오", "지금"],
-                absentee: ["세호", "재석"],
-            },
-            {
-                time: 122,
-                attendee: ["경륜", "상오", "지동"],
-                absentee: ["세호", "재석"],
-            },
-            {
-                time: 123,
-                attendee: ["경륜", "상오", "지은"],
-                absentee: ["세호", "재석"],
-            },
-            {
                 time: 124,
                 attendee: ["경륜", "상오", "영로"],
                 absentee: ["세호", "재석"],
@@ -90,27 +83,6 @@ const Test: NextPage = () => {
             {
                 time: 126,
                 attendee: ["경륜", "상오", "윤하"],
-                absentee: ["세호", "재석"],
-            },
-
-            {
-                time: 127,
-                attendee: ["경륜", "상오", "재상"],
-                absentee: ["세호", "재석"],
-            },
-            {
-                time: 136,
-                attendee: ["경륜", "상오", "영로"],
-                absentee: ["세호", "재석"],
-            },
-            {
-                time: 137,
-                attendee: ["경륜", "상오", "영로"],
-                absentee: ["세호", "재석"],
-            },
-            {
-                time: 138,
-                attendee: ["경륜", "상오", "영로"],
                 absentee: ["세호", "재석"],
             },
         ],
@@ -170,7 +142,20 @@ const Test: NextPage = () => {
     );
 };
 
-export default Test;
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    try {
+        return {
+            props: {
+                params: context.params,
+            },
+        };
+    } catch (e) {
+        console.log(e);
+        return { props: {} };
+    }
+};
+
+export default TableView;
 
 const Container = styled.div`
     width: 372px;

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -46,8 +46,9 @@ const TableView: NextPage<Props> = ({ params }) => {
     const router = useRouter();
     const { eid } = params;
     const { data, isLoading } = useParticipants(eid);
-    const selectableTimes = isLoading ? null : data.data;
-    console.log(selectableTimes);
+    const selectableTimes = isLoading
+        ? null
+        : data.data.selectableParticipleTimes.selectedDayOfWeeks;
 
     const [tableInfo, setTableInfo] = useState<tableInfoType>({
         row: 48,
@@ -93,25 +94,6 @@ const TableView: NextPage<Props> = ({ params }) => {
         TimeDataType["times"][0] | undefined
     >();
 
-    // const [mostJoinTimes, setMostJoinTimes] = useState<TimeDataType["times"]>(
-    //     []
-    // );
-
-    // useEffect(() => {
-    // let joinMax = 0;
-
-    // for (let i = 0; i < timeData.times.length; i++) {
-    //     joinMax =
-    //         timeData.times[i].attendee.length > joinMax
-    //             ? timeData.times[i].attendee.length
-    //             : joinMax;
-    // }
-    // for (let i = 0; i < timeData.times.length; i++) {
-    //     if (joinMax === timeData.times[i].attendee.length) {
-    //         setMostJoinTimes([...mostJoinTimes, timeData.times[i]]);
-    //     }
-    // }
-    // }, []);
     useEffect(() => {
         const clicked: TimeDataType["times"][0] | undefined = timeData[
             "times"
@@ -121,22 +103,27 @@ const TableView: NextPage<Props> = ({ params }) => {
 
     return (
         <Body>
-            <Navbar>
-                <Image src={shareNav} alt="share" />
-            </Navbar>
-            <H1>총 {timeData.total}명이 참여했어요!</H1>
-            <Tooltip>*시간을 클릭해보세요.</Tooltip>
-            <ViewTable
-                timeData={timeData}
-                info={tableInfo}
-                setClickedTime={setClickedTime}
-            />
-            {clickedData && (
-                <Container>
-                    <Attendee clickedData={clickedData} />
-                    {/* <ThinLine />
+            {!isLoading && (
+                <>
+                    <Navbar>
+                        <Image src={shareNav} alt="share" />
+                    </Navbar>
+                    <H1>총 {timeData.total}명이 참여했어요!</H1>
+                    <Tooltip>*시간을 클릭해보세요.</Tooltip>
+                    <ViewTable
+                        timeData={timeData}
+                        info={tableInfo}
+                        setClickedTime={setClickedTime}
+                        selectedWeeks={selectableTimes}
+                    />
+                    {clickedData && (
+                        <Container>
+                            <Attendee clickedData={clickedData} />
+                            {/* <ThinLine />
                     <MaximumTime times={mostJoinTimes} /> */}
-                </Container>
+                        </Container>
+                    )}
+                </>
             )}
         </Body>
     );

--- a/meezzle-front/pages/event/[eid]/vote.tsx
+++ b/meezzle-front/pages/event/[eid]/vote.tsx
@@ -78,7 +78,10 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
             guestLogout();
         }
         /* 제출 API 처리 필요 */
-        router.push("/");
+        router.push({
+            pathname: `/event/${eid}/congratulations`,
+            query: { voter: "true" },
+        });
     };
 
     // 이벤트 설명 보기시 발생하는 이벤트 핸들러
@@ -95,6 +98,13 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
             setNow(selectedDay[idx]);
         }
     };
+
+    useEffect(() => {
+        if (localStorage.getItem("token") === null) {
+            alert("잘못된 로그인 정보입니다.");
+            router.push(`/event/${eid}/info`);
+        }
+    }, []);
 
     const BtnPrint = (): JSX.Element => {
         if (selectedDay.length === 1) {

--- a/meezzle-front/pages/oauth/kakao.tsx
+++ b/meezzle-front/pages/oauth/kakao.tsx
@@ -17,9 +17,9 @@ const Kakao: NextPage<Props> = ({ host }) => {
     const [loginState, setLoginState] = useLogin();
     const router = useRouter();
     const { code: authCode, error: kakaoServerError } = router.query;
-    let requestUrl = 'http://localhost:3000/oauth/kakao'
-    if (host !== "localhost:3000"){
-        requestUrl = "https://meezzle.vercel.app/oauth/kakao"
+    let requestUrl = "http://localhost:3000/oauth/kakao";
+    if (host !== "localhost:3000") {
+        requestUrl = "https://meezzle.vercel.app/oauth/kakao";
     }
     const loginHandler = useCallback(
         async (code: string | string[]) => {
@@ -61,16 +61,14 @@ const Kakao: NextPage<Props> = ({ host }) => {
     );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => (
-    { 
-        props: { 
-            host: context.req.headers.host || null 
-        } 
-    }
-);
+export const getServerSideProps: GetServerSideProps = async (context) => ({
+    props: {
+        host: context.req.headers.host || null,
+    },
+});
 
 const LoaderBox = styled.div`
-    margin-top: 60%;
+    margin-top: 50vh;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 :  투표 완료/이벤트 생성 완료 뷰 작성, 로그인 스피너 위치 변경, 투표 URL 진입시 토큰 없으면 로그인 화면으로 리다이렉트 
> 작성일: 2023.1.6

# 종류
- [ ] 성능 개선
- [ ] 코드 개선
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 기타

# 변경내용
[내용]
1. 투표 완료 URL : event/[eid]/congratulations?voter=true 
이벤트 생성 완료 URL : event/[eid]/congratulations
URL로 조건부 렌더링합니다.

2. 카카오 로그인시 스피너 위치가 디바이스 높이의 가운데에 오도록 수정
3. event/[eid]/vote 진입 시 토큰이 없으면 게스트 로그인 화면(info)로 리다이렉트

*추후 revise URL에서도 수정 권한 없으면 돌려보내는건 어떨까요?
# 테스트
[간단 설명]