### PR TITLE
로그인 상태 로그아웃 전까지 계속 유지

### DIFF
--- a/meezzle-front/states/login.tsx
+++ b/meezzle-front/states/login.tsx
@@ -3,12 +3,12 @@ import { recoilPersist } from "recoil-persist";
 import { useRecoilState } from "recoil";
 import { useState, useEffect } from "react";
 
-const sessionStorage =
-    typeof window !== "undefined" ? window.sessionStorage : undefined;
+const localStorage =
+    typeof window !== "undefined" ? window.localStorage : undefined;
 
 const { persistAtom } = recoilPersist({
     key: "login",
-    storage: sessionStorage,
+    storage: localStorage,
 });
 
 export const LoginState = atom<boolean>({


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 :  다른 탭에서 로그인이 풀리는 이슈
> 작성일: 2023.1.10

# 종류
- [x] 성능 개선
- [ ] 코드 개선
- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 기타

# 변경내용

기존의 로그인 상태를 세션스토리지에 저장해서 탭마다 로그인/로그아웃 상태가 달랐습니다
이제 미쯜의 로그인 상태가 로그아웃 하기 전까지 반영구적으로 유지됩니다
다른 버그가 또 생길까봐 두렵습니다

# 테스트
[간단 설명]