### PR TITLE
카카오톡 미리보기를 위한 메타데이터 설정

### DIFF
--- a/meezzle-front/pages/_app.tsx
+++ b/meezzle-front/pages/_app.tsx
@@ -44,6 +44,19 @@ function MyApp({
                             property="og:url"
                             content="https://meezzle.xyz/"
                         />
+                        <meta property="og:type" content="website" />
+                        <meta
+                            property="og:title"
+                            content="약속은 편하게 모임은 즐겁게 meezzle!"
+                        />
+                        <meta
+                            property="og:description"
+                            content="meezzle에서 약속 시간을 편리하게 정해보세요!"
+                        />
+                        <meta
+                            property="og:image"
+                            content="https://www.meezzle.xyz/_next/static/media/character.820c8bb7.svg"
+                        />
 
                         <link
                             rel="shortcut icon"

--- a/meezzle-front/pages/_error.tsx
+++ b/meezzle-front/pages/_error.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { HomeBtn } from "../components/common/HomeBtn";
 import Navbar from "../components/common/Navbar";
 import OrangeBtn from "../components/common/OrangeBtn";
-import character from "../public/assets/character.svg";
+import character from "../public/assets/sad_character.svg";
 import Body from "../styled-components/StyledBody";
 import Head from "next/head";
 

--- a/meezzle-front/pages/event/[eid]/info.tsx
+++ b/meezzle-front/pages/event/[eid]/info.tsx
@@ -111,8 +111,6 @@ const LoginContainer = styled.div`
     flex-direction: column;
 `;
 
-
-
 const Footer = styled.div`
     display: flex;
     justify-content: center;
@@ -252,7 +250,7 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
 
     useEffect(() => {
         errorHandler();
-        if (localStorage.getItem("token") !== null){
+        if (localStorage.getItem("token") !== null) {
             setIsHost(true);
         }
     }, []);
@@ -369,6 +367,10 @@ const ReviseEvent: NextPage<Props> = ({ params }) => {
                     ) : (
                         <>
                             <Head>
+                                <meta
+                                    property="og:description"
+                                    content="링크를 타고 나의 참여 가능한 시간을 입력해보세요!"
+                                />
                                 <title>{data.data.event.title} | meezzle</title>
                             </Head>
                             <SectionContainer>

--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -230,6 +230,10 @@ const TableView: NextPage<Props> = ({ params }) => {
                 <>
                     <Head>
                         <title>
+                            <meta
+                                property="og:description"
+                                content="링크를 타고 참가자들의 투표 현황을 살펴보세요!"
+                            />
                             {isVoterFetched
                                 ? `${voterData[0].name}님의 투표 현황 | meezzle`
                                 : `${data.data.event.title}


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 : 카카오톡 링크 공유시 미리보기가 안예뻐서 사람들이 클릭을 안하고 싶음
> 작성일: 2023.1.14

# 종류
- [ ] 성능 개선
- [ ] 코드 개선
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 기타

# 변경내용

메타데이터를 추가해서 카카오톡 링크 공유시 이용자들이 피싱 사이트라고 착각하지 않도록 함

# 테스트
[간단 설명]