### PR TITLE
fix: 테이블 뷰에서 공유하기 URL 수정

### DIFF
--- a/meezzle-front/pages/event/[eid]/view.tsx
+++ b/meezzle-front/pages/event/[eid]/view.tsx
@@ -189,7 +189,7 @@ const TableView: NextPage<Props> = ({ params }) => {
 
     const onShare = () => {
         navigator.clipboard
-            .writeText(window.location.href)
+            .writeText(window.location.href.replace("view", "info"))
             .then(() => {
                 toast("링크가 복사되었습니다.", {
                     position: "top-center",


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 :  view 페이지에서 공유시 URL을 view 페이지가 아닌 info 페이지로 수정
> 작성일: 2023.1.31

# 종류
- [ ] 성능 개선
- [ ] 코드 개선
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 기타

# 변경내용
view 페이지에서 공유시 URL을 view 페이지가 아닌 info 페이지로 수정해달라는 요청이 있었습니다.
