### PR TITLE
테이블 통계 보기 크로스브라우징 이슈 해결

### DIFF
--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -149,10 +149,13 @@ const ViewTable = ({
 export default ViewTable;
 
 const TimeRow = styled.p`
-    margin: 8px 0 14px 0;
+    height: 26px;
+    padding-bottom: 14px;
+    margin: 0;
 `;
 
 const Container = styled.div`
+    display: flex;
     width: 97%;
     overscroll-behavior-x: none; // 아이폰 스와이프 방지
     margin: 0 auto;
@@ -165,7 +168,7 @@ const Container = styled.div`
 `;
 
 const Table = styled.div`
-    display: inline-block;
+    display: block;
     width: 90%;
     vertical-align: top;
 `;
@@ -212,10 +215,12 @@ const TimeBlock = styled.span<{
 `;
 
 const Time = styled.div`
-    display: inline-block;
+    display: block;
     width: 8%;
+    height: 646px;
+
     font-size: 9px;
-    margin-top: 6px;
+    margin-top: 14px;
     text-align: right;
     margin-right: 3px;
 `;


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 : [#58] 
> 작성일: 2023.3.30  

# 종류
- [ ] 성능 개선
- [ ] 코드 개선
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 기타

# 변경내용
시간을 나타내는 p태그에 고정된 높이 값을 부여해서, 브라우저의 크기에 상관없이 같은 높이를 가질 수 있도록 변경했습니다.


# 테스트
![image](https://user-images.githubusercontent.com/78628241/228803001-f070c566-17c4-4931-a7ab-3a3cda170080.png)
