### PR TITLE
Fix: 통계 테이블의 시작 시간을 투표 가능한 시작 시간부터 출력

### DIFF
--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -90,8 +90,7 @@ const ViewTable = ({
     const ref = useRef<boolean>(false);
 
     useEffect(() => {
-        // 가상의 fetch
-        // setRows([]);
+        const timeBlockStart: number = checkableTimes[0] % 100; // 선택 가능한 최초 시간대
         const makeRows = (info: any, r: number) => {
             return (
                 <div key={r}>
@@ -102,7 +101,7 @@ const ViewTable = ({
                             ? false
                             : true;
 
-                        return (
+                        return key % 100 >= timeBlockStart ? (
                             <TimeBlock
                                 col={info.col.length}
                                 key={key}
@@ -117,6 +116,8 @@ const ViewTable = ({
                                 colorWeight={colorWeight}
                                 disabled={disabled}
                             ></TimeBlock>
+                        ) : (
+                            false
                         );
                     })}
                 </div>
@@ -130,8 +131,25 @@ const ViewTable = ({
                 return <div key={idx}>{e}</div>;
             })
         );
+
+        const makeTimeRow = (hour: number) => {
+            const startTime: number = Math.floor(timeBlockStart / 2);
+            const isHalfTime: number = timeBlockStart % 2;
+            const min: number | string = isHalfTime ? 30 : "00";
+
+            if (hour === 24 && min === 30) return false; // 24:30 제외
+
+            if (hour >= startTime) {
+                return (
+                    <TimeRow key={hour}>
+                        {hour}:{min}
+                    </TimeRow>
+                );
+            } else return false;
+        };
+
         for (let i = 0; i <= 24; i++) {
-            setTime((time) => [...time, <TimeRow key={i}>{i}:00</TimeRow>]);
+            setTime((time) => [...time, makeTimeRow(i)]);
         }
     }, []);
 
@@ -217,7 +235,6 @@ const TimeBlock = styled.span<{
 const Time = styled.div`
     display: block;
     width: 8%;
-    height: 646px;
 
     font-size: 9px;
     margin-top: 14px;

--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -88,9 +88,9 @@ const ViewTable = ({
     };
 
     const ref = useRef<boolean>(false);
-
+    const timeBlockStart: number = checkableTimes[0] % 100; // 선택 가능한 최초 시간대
+    const timeBlockEnd: number = Math.max(...checkableTimes) % 100; // 선택 가능한 최후 시간대
     useEffect(() => {
-        const timeBlockStart: number = checkableTimes[0] % 100; // 선택 가능한 최초 시간대
         const makeRows = (info: any, r: number) => {
             return (
                 <div key={r}>
@@ -101,7 +101,14 @@ const ViewTable = ({
                             ? false
                             : true;
 
-                        return key % 100 >= timeBlockStart ? (
+                        if (
+                            key % 100 < timeBlockStart ||
+                            key % 100 > timeBlockEnd ||
+                            isNaN(timeBlockStart)
+                        )
+                            return false;
+
+                        return (
                             <TimeBlock
                                 col={info.col.length}
                                 key={key}
@@ -116,8 +123,6 @@ const ViewTable = ({
                                 colorWeight={colorWeight}
                                 disabled={disabled}
                             ></TimeBlock>
-                        ) : (
-                            false
                         );
                     })}
                 </div>
@@ -132,14 +137,19 @@ const ViewTable = ({
             })
         );
 
+        const startTime: number = Math.floor(timeBlockStart / 2);
+        const isHalfTime: number = timeBlockStart % 2;
+        const min: number | string = isHalfTime ? 30 : "00";
+        const endTime: number = isHalfTime
+            ? Math.floor(timeBlockEnd / 2)
+            : Math.ceil(timeBlockEnd / 2);
+
         const makeTimeRow = (hour: number) => {
-            const startTime: number = Math.floor(timeBlockStart / 2);
-            const isHalfTime: number = timeBlockStart % 2;
-            const min: number | string = isHalfTime ? 30 : "00";
+            console.log(startTime, endTime, timeBlockEnd);
 
             if (hour === 24 && min === 30) return false; // 24:30 제외
 
-            if (hour >= startTime) {
+            if (hour >= startTime && hour <= endTime) {
                 return (
                     <TimeRow key={hour}>
                         {hour}:{min}
@@ -147,7 +157,6 @@ const ViewTable = ({
                 );
             } else return false;
         };
-
         for (let i = 0; i <= 24; i++) {
             setTime((time) => [...time, makeTimeRow(i)]);
         }

--- a/meezzle-front/components/event/View/ViewTable.tsx
+++ b/meezzle-front/components/event/View/ViewTable.tsx
@@ -145,8 +145,6 @@ const ViewTable = ({
             : Math.ceil(timeBlockEnd / 2);
 
         const makeTimeRow = (hour: number) => {
-            console.log(startTime, endTime, timeBlockEnd);
-
             if (hour === 24 && min === 30) return false; // 24:30 제외
 
             if (hour >= startTime && hour <= endTime) {


### PR DESCRIPTION
> 작성자 : 신재훈
> 이  슈 :  [#63 ]
> 작성일: 2023.4.7

# 종류
- [x] 성능 개선
- [x] 코드 개선
- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 기타

# 변경내용

### Before
![image](https://user-images.githubusercontent.com/78628241/230594570-6d76263c-e745-4951-8a40-885fc1e58b1f.png)

### After
![image](https://user-images.githubusercontent.com/78628241/230594709-caf86ffa-384b-46ca-8192-48975d550ad1.png)

통계 테이블에서 선택 가능한 시간보다 이전의 시간들을 제외합니다!
